### PR TITLE
fix formatting that breaks syntax highlighting

### DIFF
--- a/connectors/JSONPlaceholder/albums.graphql
+++ b/connectors/JSONPlaceholder/albums.graphql
@@ -21,7 +21,7 @@ extend schema
 
   type User @key(fields: "id") {
     id: ID!
-    albums : [Album]
+    albums: [Album]
     @connect(
       source: "JSONPlaceholder"
       http: { GET: "/users/{$this.id}/albums" }

--- a/connectors/JSONPlaceholder/comments.graphql
+++ b/connectors/JSONPlaceholder/comments.graphql
@@ -23,7 +23,7 @@ extend schema
 
   type Post @key(fields: "id") {
     id: ID!
-    comments : [Comment]
+    comments: [Comment]
     @connect(
       source: "JSONPlaceholder"
       http: { GET: "/posts/{$this.id}/comments" }

--- a/connectors/JSONPlaceholder/photos.graphql
+++ b/connectors/JSONPlaceholder/photos.graphql
@@ -23,7 +23,7 @@ extend schema
 
   type Album @key(fields: "id") {
     id: ID!
-    photos : [Photo]
+    photos: [Photo]
     @connect(
       source: "JSONPlaceholder"
       http: { GET: "/albums/{$this.id}/photos" }

--- a/connectors/JSONPlaceholder/posts.graphql
+++ b/connectors/JSONPlaceholder/posts.graphql
@@ -22,7 +22,7 @@ extend schema
 
   type User @key(fields: "id") {
     id: ID!
-    posts : [Post]
+    posts: [Post]
     @connect(
       source: "JSONPlaceholder"
       http: { GET: "/users/{$this.id}/posts" }

--- a/connectors/JSONPlaceholder/todos.graphql
+++ b/connectors/JSONPlaceholder/todos.graphql
@@ -22,7 +22,7 @@ extend schema
 
   type User @key(fields: "id") {
     id: ID!
-    todos : [ToDo]
+    todos: [ToDo]
     @connect(
       source: "JSONPlaceholder"
       http: { GET: "/users/{$this.id}/todos" }


### PR DESCRIPTION
This might seem like a very weird PR 😓 

Generally, I noticed that GraphQL in here is not formatted with an autoformatter, and I assume there is some reasoning behind this being written in a specific way for the human eye - but in these circumstances, the space before the colon breaks syntax highlighting - which also means that the mapping language won't be syntax highlighted once I add support for that.

In VSCode:
![image](https://github.com/user-attachments/assets/abdf53ad-bc92-4233-abdd-edf78eedb71c)
On GitHub:
![image](https://github.com/user-attachments/assets/370525f0-1310-4d46-85ef-ab783c6b61b0)
